### PR TITLE
add python version and correct checkpoint path in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,5 +132,5 @@ dmypy.json
 .pyre/
 
 # Weights
-checkpoints/zdir_calc*
+nextqsm/checkpoints/zdir_calc*
 nextqsm-weights.tar

--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ Cognolato, F., O'Brien, K., Jin, J., Robinson, S., Laun, F. B., Barth, M., & Bol
 
 ## Installation
 
+Create a conda environment. Python version **3.8** is recommended, higher versions might be incompatible:  
+```bash
+conda create -n nextqsm python=3.8 
+conda activate nextqsm 
+```
+
 NeXtQSM is available via pip:
 
 ```bash


### PR DESCRIPTION
NeXtQSM requires a lower version of Python. I tested on Python 3.12 which is incompatible, but Python 3.8 is working